### PR TITLE
Fixes for upload schema example

### DIFF
--- a/content/deploy/install/services.md
+++ b/content/deploy/install/services.md
@@ -115,7 +115,7 @@ If enabling the Audit Trail, also the include the configuration in [Enable chang
     curl --location --request POST 'http://localhost:<FORWARDED_PORT>/admin/schema' \
     --header 'Authorization: Bearer <TOKEN>' \
     --header 'Content-Type: application/octet-stream' \
-    --data-binary '<SCHEMA_FILE>’
+    --data-binary '@<SCHEMA_FILE>’
     ```
 
     This creates more roles.

--- a/content/deploy/install/services.md
+++ b/content/deploy/install/services.md
@@ -114,7 +114,6 @@ If enabling the Audit Trail, also the include the configuration in [Enable chang
     ```bash
     curl --location --request POST 'http://localhost:<FORWARDED_PORT>/admin/schema' \
     --header 'Authorization: Bearer <TOKEN>' \
-    --data grant_type=urn:ietf:params:oauth:grant-type:uma-ticket" \
     --header 'Content-Type: application/octet-stream' \
     --data-binary '<SCHEMA_FILE>’
     ```


### PR DESCRIPTION
 Curl --data-binary filename needs to start with '@' so it is read as a file.    

Form field grant_type missing opening quotes. With correct quoting Baas throws error - Unexpected Name \"grant_type\" so have removed it.

