### PR TITLE
Fix checksums by using manifest checksums instead of configuration ch…

### DIFF
--- a/static/checksums/v3.2.1-checksums.txt
+++ b/static/checksums/v3.2.1-checksums.txt
@@ -1,35 +1,35 @@
 Admin:
 registry.gitlab.com/libremfg/frontend/libre-admin-ui:v3.2.1
-sha256:993fa7faed0b6f26f08d9a51588232634826e67a94038a4ded9f286670937666
+sha256:36a9b1f79b29cc7daf2afa822ef750e1cab820b7176062189f9075ea5d404d09
 
 BPMN Engine:
 registry.gitlab.com/libremfg/bpmn-engine:v3.2.1
-sha256:e74e75107099b9cbff68f3439adb6fa05c46eea0cf9a774d0913a4d324dd395c
+sha256:92be0b779445f16b671e33282ce6fe0acce099542acb1628cd879c8919162716
 
 BAAS:
 registry.gitlab.com/libremfg/baas:v3.2.1
-sha256:852b5a05006a285f7ec42aeb810e0c556b91253232a4d40b355c4200beeeb95b
+sha256:4fe59c5343879c8c143494dd0e5ae9ad2cecf99a46f2fcb80d8faaa7e9469341
 
 Libre Core:
 registry.gitlab.com/libremfg/libre-core:v3.2.1
-sha256:649ebe3176d998c4e260f55101371244eb0f7663cc0f9c2a8d6ca85d6d649cd7
+sha256:dc8e5c66f5b0bc20b7f871836df820dbb95de1128f9bf5b2ca637d6c5904da38
 
 Libre Agent:
 registry.gitlab.com/libremfg/libre-agent:v3.2.1
-sha256:ca3b54efbbbd0ef712ce5fbbea0e360422d089c38562f778970b92e15337feed
+sha256:fd4f4c000e60997b9c1605183dc92b60510418e50b55b82b3a61878a8d689e52
 
 Libre Audit:
 registry.gitlab.com/libremfg/libre-audit:v3.2.1
-sha256:66ec60553aee58e8f5d685a6c463edfabf94d38654220c6841f652e3670001ee
+sha256:07c72b30327d86a3147bc5a5031c6f747d3325f799cb223073c9fdacf452d4ea
 
 Libre Audit Postgres:
 registry.gitlab.com/libremfg/libre-audit/postgres:v3.2.1
-sha256:bf167fbc5d2d00198497a23b7b34e67674cb687e3ae4b7cd7782c371909853d9
+sha256:d48d19f8778f950e948dd27ae459dbca55b353bb3518616e9f08314f1f897d3a
 
 Libre Keycloak Theme:
 registry.gitlab.com/libremfg/frontend/libre-keycloak-theme:v3.2.1
-sha256:a4051489a25c27b797ff8620dce979838488802037a4a0d7df0b382c8635e24e
+sha256:a993e795a70b42310437608ae92d631bc3d9ec534eceeadd9e725cf89c8eab75
 
 Libre Router Init:
 registry.gitlab.com/libremfg/libre-router-init:v3.2.1
-sha256:98e3de9178eb0a678d155c7f452de5c9168029d57bb812015f7afd01881062b6
+sha256:e11380d288f579b6803fd34b76731f7df1e7b7f4907261afb3a66a31a562088e


### PR DESCRIPTION
### Fix 
 -  Fix checksums by using manifest checksums instead of configuration checksums for v3.2.1